### PR TITLE
[Bug #55] Reload available term types when language is switched

### DIFF
--- a/src/component/term/TermTypesEdit.tsx
+++ b/src/component/term/TermTypesEdit.tsx
@@ -27,6 +27,12 @@ export class TermTypesEdit extends React.Component<TermTypesEditProps> {
         this.props.loadTypes();
     }
 
+    public componentDidUpdate(prevProps: Readonly<TermTypesEditProps>) {
+        if (Object.getOwnPropertyNames(prevProps.availableTypes).length > 0 && Object.getOwnPropertyNames(this.props.availableTypes).length === 0) {
+            this.props.loadTypes();
+        }
+    }
+
     public onChange = (val: Term | null) => {
         this.props.onChange(val ? [val.iri, VocabularyUtils.TERM] : [VocabularyUtils.TERM]);
     };

--- a/src/component/term/__tests__/TermTypesEdit.test.tsx
+++ b/src/component/term/__tests__/TermTypesEdit.test.tsx
@@ -72,4 +72,15 @@ describe("TermTypesEdit", () => {
                                loadTypes={loadTypes} onChange={onChange} {...intlFunctions()}/>);
         expect(loadTypes).toHaveBeenCalled();
     });
+
+    it("reloads types when they are cleared after language switch", () => {
+        const availableTypes = {};
+        availableTypes[VocabularyUtils.TERM] = new Term({iri: VocabularyUtils.TERM, label: langString("Term")});
+        const wrapper = shallow<TermTypesEdit>(<TermTypesEdit termTypes={[VocabularyUtils.TERM]} availableTypes={availableTypes}
+                               loadTypes={loadTypes} onChange={onChange} {...intlFunctions()}/>);
+        (loadTypes as jest.Mock).mockReset();
+        wrapper.setProps({availableTypes: {}});
+        wrapper.update();
+        expect(loadTypes).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Resolves #55 