### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,9 @@ name: Docker
 
 on:
   push:
-    # Publish `main` as Docker `latest` image.
+    # Publish `master` as Docker `latest` image.
     branches:
-      - main
+      - master
 
 env:
   # TODO: Change variable to your image's name.


### PR DESCRIPTION
Changing the base branch for docker build from `main` to `master` because of compatibility issues.